### PR TITLE
Fix for Firefox issue TypeError nativeSelection is null

### DIFF
--- a/vendor/assets/javascripts/weblinc-wysihtml5-rails/wysihtml5.js
+++ b/vendor/assets/javascripts/weblinc-wysihtml5-rails/wysihtml5.js
@@ -2972,7 +2972,7 @@ rangy.createModule("DomUtil", function(api, module) {
             if (implementsControlRange && implementsDocSelection && sel.docSelection.type == CONTROL) {
                 updateControlSelection(sel);
             } else {
-                sel._ranges.length = sel.rangeCount = sel.nativeSelection.rangeCount;
+                sel._ranges.length = sel.rangeCount = (sel.nativeSelection ? sel.nativeSelection.rangeCount : 0);
                 if (sel.rangeCount) {
                     for (var i = 0, len = sel.rangeCount; i < len; ++i) {
                         sel._ranges[i] = new api.WrappedRange(sel.nativeSelection.getRangeAt(i));


### PR DESCRIPTION
There is a issue with Firefox that will cause a problem in the admin anytime we use wysiwygs within tabs (tabs.js) for content blocks. This solves it. Adapted from here: 
https://github.com/glebm/bootstrap-wysihtml5-rails/blob/master/vendor/assets/javascripts/bootstrap-wysihtml5/rangy/rangy-core.js#L2958